### PR TITLE
Handle the exceptions and explore the status of the remaining PRs

### DIFF
--- a/doit.py
+++ b/doit.py
@@ -109,8 +109,12 @@ def find_pr(args):
             url = f"https://api.github.com/repos/{args.owner}/{args.repo}/statuses/{pr_last_commit_sha}"
             statuses_filtered = [s for s in _get_all(url, headers=_headers(args)) if s["context"] == args.successful_check]
             logging.debug(f"PR {pr_number}/{pr_issue_url} have '{args.successful_check}' checks from {', '.join([s['updated_at'] for s in statuses_filtered])}")
-            status_max = max(statuses_filtered, key=lambda s: s["updated_at"])
-            if len(statuses_filtered) == 0 or status_max["state"] != "success":
+            if len(statuses_filtered) != 0:
+                status_max = max(statuses_filtered, key=lambda s: s["updated_at"])
+                if status_max["state"] != "success":
+                    logging.debug(f"PR {pr_number}/{pr_issue_url} - {pr_last_commit_sha} does not have expected state, skipping it")
+                    continue
+            else:
                 logging.debug(f"PR {pr_number}/{pr_issue_url} does not have expected '{args.successful_check}' check, skipping it")
                 continue
 


### PR DESCRIPTION
#### Highlights of the PR
1. Handle the exceptions and explore the status of the remaining PRs
```
[cmusali@cmusali my-github-helper]$ ./doit.py --token ${GH_TOKEN} find_pr --owner RedHatInsights --repo rhsm-subscriptions --successful-check 'ci.ext.devshift.net PR build' --author-in-org RedHatInsights
Traceback (most recent call last):
  File "./doit.py", line 209, in <module>
    sys.exit(main())
  File "./doit.py", line 205, in main
    return args.func(args)
  File "./doit.py", line 112, in find_pr
    status_max = max(statuses_filtered, key=lambda s: s["updated_at"])
ValueError: max() arg is an empty sequence

```

```
[cmusali@cmusali my-github-helper]$ git checkout fix-ESSNTL-3481 
Switched to branch 'fix-ESSNTL-3481'

[cmusali@cmusali my-github-helper]$ ./doit.py --token ${GH_TOKEN} find_pr --owner RedHatInsights --repo rhsm-subscriptions --successful-check 'ci.ext.devshift.net PR build' --author-in-org RedHatInsights
2236 https://api.github.com/repos/RedHatInsights/rhsm-subscriptions/issues/2236 2023-06-15T16:19:05Z e4b87fe90519c639a9127a7b8ffb94b2654f3b4b

```